### PR TITLE
Add twitter card metadata to blog posts

### DIFF
--- a/_includes/_header.html
+++ b/_includes/_header.html
@@ -16,4 +16,11 @@
   <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/css/normalize.css">
   <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/css/blog.css"/>
   <link rel="stylesheet" type="text/css" href="{{site.baseurl}}/css/768.css">
+  {% if page.has_card %}
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@milafrerichs" />
+    <meta name="twitter:title" content="{{page.card.title}}" />
+    <meta name="twitter:description" content="{{page.card.description}}" />
+    <meta name="twitter:image" content="{{page.card.image_url}}" />
+  {% endif %}
 </head>

--- a/_posts/2016-07-18-restart.md
+++ b/_posts/2016-07-18-restart.md
@@ -1,6 +1,11 @@
 ---
 title: Starting to blog again
 layout: blog-single
+has_card: true
+card:
+  title: "Mila Frerichs's Blog: Starting a blog again"
+  description: "I'm restarting my blog and commiting to publish every day"
+  image_url: http://milafrerichs.de/assets/images/ruby.jpg
 ---
 I wanted to restart my personal blog for years and did not do it.
 But I started reading [Just Fucking Ship](http://justfuckingship.com) and wanted to start shipping. And I thought I start with my blog.


### PR DESCRIPTION
add metadata to use twitter cards with the blog to drive more traffic
and getter insights
