### PR TITLE
Use Vega-embed to include visualizations

### DIFF
--- a/_includes/_create_viz.html
+++ b/_includes/_create_viz.html
@@ -1,0 +1,12 @@
+---
+---
+<script type="text/javascript">
+{% assign post_date= page.date | date: '%Y-%m-%d' %}
+{% for viz in site.data.visualizations[post_date] %}
+  vizSpec{{forloop.index}} = {{viz.data|jsonify}};
+  vizSpecLite{{forloop.index}}  = { mode: 'vega-lite', spec: vizSpec{{forloop.index}} , actions: false };
+  vg.embed("{{viz.id}}", vizSpecLite{{forloop.index}} , function(error, result) {
+      return;
+  });
+{% endfor %}
+</script>

--- a/_includes/_header.html
+++ b/_includes/_header.html
@@ -26,4 +26,5 @@
     <meta name="twitter:image" content="{{page.domain}}{{page.images_path}}/{{page.image.url}}" />
     {% endif %}
   {% endif %}
+  {% include _viz.html %}
 </head>

--- a/_includes/_viz.html
+++ b/_includes/_viz.html
@@ -1,0 +1,6 @@
+{% if page.has_viz %}
+  <script src="http://vega.github.io/vega-editor/vendor/d3.min.js" charset="utf-8"></script>
+  <script src="http://vega.github.io/vega-editor/vendor/vega.js" charset="utf-8"></script>
+  <script src="http://vega.github.io/vega-editor/vendor/vega-lite.js" charset="utf-8"></script>
+  <script src="http://vega.github.io/vega-editor/vendor/vega-embed.js" charset="utf-8"></script>
+{% endif %}


### PR DESCRIPTION
add new json data as an array for each visualization you want to include
for a blog post.
put them in the _data/visualizations folder and name them the same date
as the blogpost (need to change that)
use vega lite as the post
